### PR TITLE
Registration blowup fix

### DIFF
--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -15,7 +15,7 @@
   </div>
   <div>
     <%= f.label :email %>
-    <%= f.email_field :email %>
+    <%=f.email_field :email , :required => true, :pattern => '[^@]+@[^@]+\.[a-zA-Z]{2,6}' %>
   </div>
   <div>
     <%= f.label :password %>


### PR DESCRIPTION
Hello
Previously, registering with an empty email field blew up the web page. This has no been fixed. 
