### PR TITLE
fixed e-mail validation blow up issue with registration

### DIFF
--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -15,7 +15,7 @@
   </div>
   <div>
     <%= f.label :email %>
-    <%= f.email_field :email %>
+    <%=f.email_field :email , :required => true, :pattern => '[^@]+@[^@]+\.[a-zA-Z]{2,6}' %>
   </div>
   <div>
     <%= f.label :password %>


### PR DESCRIPTION
Set-up validation for e-mail input to prevent site "blow up" when field left blank. 
