### PR TITLE
fixed e-mail validation blow up issue with registration

### DIFF
--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -15,7 +15,7 @@
   </div>
   <div>
     <%= f.label :email %>
-    <%= f.email_field :email %>
+    <%=f.email_field :email , :required => true, :pattern => '[^@]+@[^@]+\.[a-zA-Z]{2,6}' %>
   </div>
   <div>
     <%= f.label :password %>


### PR DESCRIPTION
Bug: 
-User attempts to register 
-Upon filling out all the correct data on the form and submitting with email left blank  
-Site renders error page 

Bug fix:
-Set-up validation for e-mail input when field left blank.
