### PR TITLE
Email bug

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   has_secure_password
 
-  validates :email, uniqueness: {case_sensitive: false}
+  validates :email, presence: true, uniqueness: {case_sensitive: false}
   validates :name, presence: true, uniqueness: {case_sensitive: false}
 
   before_validation do

--- a/spec/features/email_spec.rb
+++ b/spec/features/email_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+require 'capybara/rails'
+
+feature 'Auth' do
+
+	scenario 'User forgets to put in their email' do
+	 c = 'registrations'
+	 a = 'new'
+	visit (url_for :controller =>c, :action => a) 
+	within(".registration-form") {click_on 'Register'}
+	expect(page).to have_content('Email can\'t be blank')
+
+	end
+end


### PR DESCRIPTION
While the new Pivotal Tracker is being set up, I figured I'd get submit the bug fix I finished for review.

The bug, where the screen would break if the user registers without an email was due to a missing form validation field in app/models/user.rb The validator checked for a presence of a username, but not for an email.

Adding an additional check on the email validator and test file fixed the email, and the user is now redirected back to the form and told to add an email address.
