### PR TITLE
No Email In Register Creates Problem

### DIFF
--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -1,31 +1,31 @@
 <%= form_for @user, url: registrations_path, html: { class: "registration-form" } do |f| %>
-  <h1>Register</h1>
+<h1>Register</h1>
 
-  <% if f.object.errors.any? %>
-    <ul class="errors">
-      <% f.object.errors.full_messages.each do |error| %>
-        <li><%= error %></li>
-      <% end %>
-    </ul>
-  <% end %>
+<% if f.object.errors.any? %>
+<ul class="errors">
+    <% f.object.errors.full_messages.each do |error| %>
+    <li><%= error %></li>
+    <% end %>
+</ul>
+<% end %>
 
-  <div>
+<div>
     <%= f.label :name %>
-    <%= f.text_field :name, autofocus: true %>
-  </div>
-  <div>
+    <%= f.text_field :name, autofocus: true, :required => true %>
+</div>
+<div>
     <%= f.label :email %>
-    <%= f.email_field :email %>
-  </div>
-  <div>
+    <%= f.email_field :email, :required => true %>
+</div>
+<div>
     <%= f.label :password %>
-    <%= f.password_field :password %>
-  </div>
-  <div>
+    <%= f.password_field :password, :required => true %>
+</div>
+<div>
     <%= f.label :password_confirmation, "Confirm" %>
-    <%= f.password_field :password_confirmation %>
-  </div>
-  <div>
+    <%= f.password_field :password_confirmation, :required => true %>
+</div>
+<div>
     <%= f.submit "Register" %>
-  </div>
+</div>
 <% end %>

--- a/spec/features/auth_spec.rb
+++ b/spec/features/auth_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'capybara/rails'
 
-feature 'Auth' do
+feature 'Register' do
 
   scenario 'Users can login and out' do
     create_user email: "user@example.com"

--- a/spec/features/register_spec.rb
+++ b/spec/features/register_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+require 'capybara/rails'
+
+feature 'Auth' do
+    scenario 'Testing to see if email is needed' do
+        create_user email: 'cantbuymelove@beatles.com'
+        visit root_path
+        within(".auth") { click_on "Register" }
+        expect(page).to have_content("Register")
+
+        fill_in "Email", with: 'cantbuymelove@beatles.com'
+        fill_in "Password", with: 'password'
+        within(".registration-form"){click_on "Register"}
+        expect(current_path).to eq '/registrations'
+    end
+end


### PR DESCRIPTION
The bug: Entire website crashes when entering a new user without an email.
The fix: Create validations for email. Since I was on it, I created validations on each input.
