### PR TITLE
Fixed Email Form Bug

### DIFF
--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -15,7 +15,7 @@
   </div>
   <div>
     <%= f.label :email %>
-    <%= f.email_field :email %>
+    <%= f.email_field :email, :required => true %>
   </div>
   <div>
     <%= f.label :password %>


### PR DESCRIPTION
There was a serious bug during the registration process where if the user tries to submit the registration form without entering an email address, the form with submit and cause everything to break down. You can replicate this error by trying to register yourself by filling out all the form components other than the email and it will create an error for you too. I created a fix for this problem by making the email field required and this causes nothing to break anymore. 
