### PR TITLE
App crashes when user clicks submit without entering email

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   has_secure_password
 
-  validates :email, uniqueness: {case_sensitive: false}
+  validates :email, presence: true, uniqueness: {case_sensitive: false}
   validates :name, presence: true, uniqueness: {case_sensitive: false}
 
   before_validation do


### PR DESCRIPTION
User fills out username, password, and confirm password then hits submit with leaving email field blank causes app to crash.

I added a key value of true to the email field so if left blank an error message appears, notifying the user that the email field needs to be filled out in order to continue. 
