### PR TITLE
Lissa fix bug03

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   has_secure_password
 
-  validates :email, uniqueness: {case_sensitive: false}
+  validates :email, presence: true, uniqueness: {case_sensitive: false}
   validates :name, presence: true, uniqueness: {case_sensitive: false}
 
   before_validation do

--- a/spec/features/auth_spec.rb
+++ b/spec/features/auth_spec.rb
@@ -16,4 +16,16 @@ feature 'Auth' do
     expect(page).to have_content("user@example.com")
   end
 
+  scenario 'An error is shown if the user forgets to register with an email' do
+    visit root_path
+    within(".auth") { click_on "Register"}
+    expect(page).to have_content("Register")
+
+    fill_in "Name", with: "test"
+    fill_in "Password", with: "password"
+    fill_in "Confirm", with: "password"
+    within(".registration-form") { click_on "Register" }
+    expect(page).to have_content("Email can't be blank")
+end
+
 end


### PR DESCRIPTION
There was a bug where the app would crash if the user attempted to register without an email address. This was because there was no `presence: true` property in app/models/user.rb for the email property. I added that and also added a test to make sure an error is shown in the form if you try to register without adding an email.
