### PR TITLE
Empy Email Field Bug Fix

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   has_secure_password
 
-  validates :email, uniqueness: {case_sensitive: false}
+  validates :email, presence: true, uniqueness: {case_sensitive: false}
   validates :name, presence: true, uniqueness: {case_sensitive: false}
 
   before_validation do


### PR DESCRIPTION
Empy Email Field Bug:
When a user goes through the sign-up process and does not enter an email, the application throws an error rather than notifying the user to enter an email.

Bug Fix
Added `presence: true` to app/models/user.rb to fix the above bug.
